### PR TITLE
Detect and keep aliases that don't match the filename

### DIFF
--- a/apps/plugin/src/app/utils/serialize-query.fn.ts
+++ b/apps/plugin/src/app/utils/serialize-query.fn.ts
@@ -64,10 +64,16 @@ export const serializeQuery = async (
             serializedQuery = serializedQuery.replace(match[1] + '\\|', '');
           } else {
             // Name and alias are different. Need to remove the path and keep the alias
-            serializedQuery = serializedQuery.replace(
-              match[1],
-              path.parse(name).name
-            );
+            if (name.endsWith('.md')) {
+              // For .md we can keep just the note name without extension
+              serializedQuery = serializedQuery.replace(
+                match[1],
+                path.parse(name).name
+              );
+            } else {
+              // File types not .md need to keep full filename
+              serializedQuery = serializedQuery.replace(match[1], name);
+            }
           }
         }
       }
@@ -83,6 +89,8 @@ export const serializeQuery = async (
         // Matched array
         // mathc[0]: Full matched string
         // match{1]: Matched group 1 = filepath
+        // mathc[2]: alias
+        console.log(serializedQuery);
         if (isNameUnique(path.basename(match[1]))) {
           serializedQuery = serializedQuery.replace(match[1] + '|', '');
         }


### PR DESCRIPTION
I set up a query that effectively aliases the name. I wanted to display "Who is the Quantum Gardener?" instead of "Who is the Quantum Gardener". The problem arises because we can't have ? in filenames.

In my vault I use the title property for this so the query was:

`<!-- QueryToSerialize: table without id link(file.name, default(title,file.name)) as Note, default(date(updated),date(datetime)) as Date from "notes" sort default(date(updated),date(datetime)) desc limit 50 -->`

Native Dataview handles this properly and displayed "Who is the Quantum Gardener?" as an alias for "Who is the Quantum Gardener".  Hover over the link with the ? and the correct page displays.

In this plugin, the previous changes to remove the filename stripped out the alias completely. We assumed they were the same. So there was now a link to `[[Who is the Quantum Gardener?]]` instead of the expected `[[Who is the Quantum Gardener|Who is the Quantum Gardener?]]

This change now checks for a valid alias as one that does not match the filename. If it's valid, the replace is handled differently.