### PR TITLE
feat(plugin): add device-local "disable on this device" toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Turning Dataview queries into Markdown also ensures that the generated content a
 
 The [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin MUST be installed for this plugin to function correctly.
 
+Obsidian **1.8.7 or later** is required.
+
 ## Installation
 
 ### Community plugins (recommended)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,12 @@ nav_order: 3
 
 In the settings of the plugin, you can configure:
 
+## Device Settings
+
+- **Disable on this device**: When enabled, the plugin is fully disabled on the current device only. It performs no automatic or manual serialization, registers no file-event listeners, hides the per-query refresh buttons, and its commands do nothing (they show a brief notice instead). This is useful when you want the plugin active on your desktop but completely inactive on, for example, your phone or tablet.
+
+  Unlike every other setting, this one is **stored locally on the device** and is **never synced** to your other devices (it is not written to the plugin's `data.json`). Flip it on wherever you want the plugin to stay inert; your other devices are unaffected. The change takes effect immediately — no reload required.
+
 ## General Settings
 
 - **Disable automatic updates**: When enabled, the plugin will not automatically serialize queries when files are created, modified, or renamed. You can still manually serialize queries using the command palette. This is useful if you prefer full control over when queries are updated.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Features
+
+* **settings:** added a device-local "Disable on this device" toggle that fully disables the plugin on a single device without syncing the choice to your other devices
+
+### Notes
+
+* **compatibility:** minimum required Obsidian version is now 1.8.7 (needed for device-local storage)
+
 ## 2.7.0 (2026-05-15)
 
 ### Features

--- a/docs/superpowers/specs/2026-06-17-disable-on-device-design.md
+++ b/docs/superpowers/specs/2026-06-17-disable-on-device-design.md
@@ -1,0 +1,110 @@
+# Design: Device-local "Disable on this device" toggle
+
+Date: 2026-06-17
+Status: Approved
+
+## Goal
+
+Let a user make the plugin fully inert on a single device, without that choice
+propagating to their other devices through sync. Primary use case: disable the
+plugin on a phone/tablet while keeping it active on the desktop.
+
+## Why a normal setting does not work
+
+Settings persisted via `Plugin.saveData()` are written to the plugin's
+`data.json`. That file is synchronized by Obsidian Sync (and by Git / Syncthing
+setups), so any value stored there would propagate to every device. A
+per-device, non-synced flag therefore cannot live in `PluginSettings`.
+
+## Storage
+
+Use Obsidian's device-local store, which is backed by the browser's
+`localStorage`, scoped per-vault, and never synced:
+
+- `app.saveLocalStorage(key, value)` to write.
+- `app.loadLocalStorage(key)` to read.
+
+These APIs are `@since 1.8.7`, so `manifest.json` `minAppVersion` is bumped
+`1.4.10` → `1.8.7`. `versions.json` is updated automatically by the release
+script (`scripts/version-bump.ts`) from the manifest's `minAppVersion`, so no
+manual edit is needed there.
+
+Details:
+
+- New constant in `src/app/constants.ts`:
+  `DEVICE_DISABLED_STORAGE_KEY = 'dataview-serializer:disabled-on-device'`.
+- The flag is stored as the string `'true'` when disabled; any other value
+  (including missing/`null`) means enabled.
+- The flag is **NOT** a member of `PluginSettings` and is never passed to
+  `saveData()`/`loadData()`.
+- Two thin helpers on the plugin:
+  - `isDisabledOnDevice(): boolean`
+  - `setDisabledOnDevice(value: boolean): void`
+
+## Behavior when the toggle is ON (fully inert)
+
+- **File events:** not registered in `initializePlugin()`; live-unregistered
+  when the toggle is switched on.
+- **`processFile()`:** early-return guard at the very top. Defense in depth so
+  the forced-update scheduler and any programmatic caller are also inert.
+- **Commands:** remain registered, but every command callback guards first:
+  `if (this.isDisabledOnDevice()) { new Notice('Dataview Serializer is disabled on this device'); return }`.
+- **Refresh button:** the CodeMirror editor extension receives a new live
+  callback `isDeviceDisabled: () => boolean`; when it returns true the extension
+  renders no widgets.
+- **Settings tab:** a new device-local section is rendered first, containing the
+  toggle and a short note that the choice is device-specific and not synced.
+  When ON, a banner at the top of the tab states the plugin is currently inert
+  on this device. All other settings remain editable.
+
+## Live toggling (no reload required)
+
+On change:
+
+1. Persist via `setDisabledOnDevice(value)`.
+2. Apply immediately:
+   - Disabling: call `unregisterEventHandlers()`.
+   - Enabling: call `setupEventHandlers()` only if the synced
+     `disableAutomaticUpdates` setting is false.
+3. Re-render the settings tab to show/hide the banner.
+
+Commands, `processFile()`, and the refresh button all read the flag live, so no
+Obsidian reload is needed.
+
+## Interaction with existing `disableAutomaticUpdates`
+
+Independent and orthogonal:
+
+- Device-disable is a per-device master switch (not synced).
+- `disableAutomaticUpdates` remains the synced, all-devices auto-update switch.
+
+When re-enabling the device, event handlers are set up only if
+`disableAutomaticUpdates` is false.
+
+## Files touched
+
+- `manifest.json` — bump `minAppVersion` to `1.8.7`.
+- `src/app/constants.ts` — new storage-key constant.
+- `src/app/utils/device-disabled.ts` (new) — pure helpers over an app-like
+  store interface (`loadLocalStorage`/`saveLocalStorage`).
+- `src/app/plugin.ts` — helpers, guards in `initializePlugin`/`processFile`/each
+  command, live toggle wiring, pass the gate callback to the editor extension.
+- `src/app/refresh-button-extension.ts` — accept and honor `isDeviceDisabled`.
+- `src/app/settings/settings-tab.ts` — new device-local section + banner.
+- Tests: `.spec.ts` covering the helper read/write semantics and the guard
+  (mocking `loadLocalStorage`/`saveLocalStorage`).
+- Docs: `README.md`, `docs/configuration.md`, `docs/release-notes.md`,
+  `documentation/history/2026-06-17.md`, and a new Business Rule recording that
+  this flag must never be synced.
+
+## Non-goals (YAGNI)
+
+- No automatic platform-based disabling (e.g. auto-disable on all mobile
+  devices). The toggle is manual and per-device only.
+- No hiding of commands from the palette; disabled commands no-op with a notice.
+
+## Business rule introduced
+
+The device-disable flag MUST be stored only in device-local storage
+(`app.loadLocalStorage`/`saveLocalStorage`) and MUST NEVER be written to
+`data.json` or otherwise synced.

--- a/documentation/Business Rules.md
+++ b/documentation/Business Rules.md
@@ -17,3 +17,9 @@ Truthy means: boolean `true`, non-zero numbers, or any non-empty string that is 
 The exact key is defined by `IGNORE_FRONTMATTER_KEY` in `src/app/constants.ts`. Underscores are used (not dashes) to keep the key compatible with Dataview field-access syntax (`file.dataview_serializer_ignore`).
 
 Conversion and removal commands (`convert-dataview-query-at-cursor`, `convert-all-dataview-queries-in-file`, `remove-all-queries-in-current-file`, `insert-dataview-serializer-block`) are NOT subject to this rule: they only manipulate marker syntax, they do not run Dataview queries.
+
+## Device-local disable flag
+
+The per-device "Disable on this device" flag MUST be stored only in device-local storage via `app.loadLocalStorage`/`app.saveLocalStorage` (key `DEVICE_DISABLED_STORAGE_KEY` in `src/app/constants.ts`). It MUST NEVER be a member of `PluginSettings`, written to `data.json`, or otherwise synced — its entire purpose is to stay local to the device it is toggled on.
+
+When the flag is set on a device, the plugin MUST be fully inert there: no file-event listeners registered, `processFile` short-circuits immediately (covering schedulers and any programmatic caller), all commands no-op with a notice, and the per-query refresh buttons render nothing. The flag is orthogonal to the synced `disableAutomaticUpdates` setting; when the device flag is cleared, event handlers are re-registered only if `disableAutomaticUpdates` is false.

--- a/documentation/history/2026-06-17.md
+++ b/documentation/history/2026-06-17.md
@@ -1,0 +1,71 @@
+# 2026-06-17 — Device-local "Disable on this device" toggle
+
+Added a per-device switch that fully disables the plugin on the current device
+only, without syncing the choice to other devices.
+
+## Key decisions
+
+- The flag is **not** part of `PluginSettings`. `saveData()` writes to
+  `data.json`, which Obsidian Sync / Git / Syncthing propagate to every device.
+  A non-synced flag must live in device-local storage instead.
+- Used Obsidian's `app.loadLocalStorage`/`app.saveLocalStorage` (vault-scoped
+  browser `localStorage`, never synced). These are `@since 1.8.7`, so
+  `manifest.json` `minAppVersion` was bumped `1.4.10` → `1.8.7`.
+  `versions.json` is updated automatically by `scripts/version-bump.ts` at
+  release time from the manifest's `minAppVersion`.
+- "Disable" means **fully inert** (user's choice): no file events, no automatic
+  or forced processing, commands no-op with a notice, refresh buttons hidden.
+- Trigger is a **manual per-device toggle only** — no automatic platform-based
+  disabling (YAGNI). Spec: `docs/superpowers/specs/2026-06-17-disable-on-device-design.md`.
+- Toggle applies live (no reload): commands, `processFile`, and the refresh
+  button read the flag on each use; event handlers are (un)registered on change.
+
+## Source code
+
+- `src/app/constants.ts`: added `DEVICE_DISABLED_STORAGE_KEY = 'dataview-serializer:disabled-on-device'`.
+- `src/app/utils/device-disabled.ts` (new): pure helpers `isDisabledOnDevice(store)`
+  and `setDisabledOnDevice(store, disabled)` over a minimal `DeviceLocalStore`
+  interface (`loadLocalStorage`/`saveLocalStorage`). Stores the string `'true'`
+  when disabled; clears the key (writes `null`) when enabled.
+- `src/app/utils/device-disabled.spec.ts` (new): read/write round-trip, default
+  state, unrelated-value handling, key-clearing semantics.
+- `src/app/plugin.ts`:
+    - `isDisabledOnDevice()` / `setDisabledOnDevice(disabled)` wrappers over the
+      helpers (the latter also live-(un)registers event handlers).
+    - `blockedByDeviceDisable()` private guard (notice + `true`) called at the top
+      of all six command callbacks.
+    - `initializePlugin`: skips `setupEventHandlers()` when disabled on device.
+    - `processFile`: early return when disabled on device (defense in depth).
+    - Passes `() => this.isDisabledOnDevice()` to `refreshButtonExtension`.
+- `src/app/refresh-button-extension.ts`: new `isDeviceDisabled` callback;
+  `buildDecorations` returns `Decoration.none` when it reports true.
+- `src/app/settings/settings-tab.ts`: new `renderDeviceDisableToggle()` (rendered
+  first) and `renderDeviceDisabledBanner()` (shown when disabled). Toggle calls
+  `this.display()` to refresh the banner.
+- `src/styles.src.css`: `.dvs-device-disabled-banner` class.
+- `manifest.json`: `minAppVersion` → `1.8.7`.
+
+## Documentation
+
+- `documentation/Business Rules.md`: new "Device-local disable flag" rule
+  (never synced; fully inert behavior).
+- `docs/configuration.md`: new "Device Settings" section.
+- `docs/release-notes.md`: "Unreleased" entry + compatibility note.
+- `README.md`: pre-requisites now state Obsidian 1.8.7+.
+
+## Verification
+
+`bun run tsc`, `bun run lint` (--max-warnings 0), `bun test` (503 pass), and
+`bun run build` all pass.
+
+## Manual runtime verification needed
+
+Cannot self-verify UI behavior. In a live vault, confirm:
+
+1. Toggling "Disable on this device" ON makes file edits no longer auto-serialize,
+   the refresh buttons disappear, and running any command shows the
+   "disabled on this device" notice.
+2. Toggling OFF restores automatic updates (unless "Disable automatic updates" is
+   also on), refresh buttons, and commands — without an Obsidian reload.
+3. The flag does NOT appear in `data.json` and does NOT propagate to another
+   synced device.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Dataview Serializer",
     "description": "Serialize Dataview queries to Markdown, and keep the Markdown representation up to date.",
     "version": "2.7.0",
-    "minAppVersion": "1.4.10",
+    "minAppVersion": "1.8.7",
     "isDesktopOnly": false,
     "author": "Sebastien Dubois",
     "authorUrl": "https://dsebastien.net",

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -16,6 +16,16 @@ export const MARKDOWN_FILE_EXTENSION = 'md'
  */
 export const IGNORE_FRONTMATTER_KEY = 'dataview_serializer_ignore'
 
+/**
+ * Key used to persist the per-device "disable on this device" flag.
+ *
+ * Stored via `app.saveLocalStorage`/`app.loadLocalStorage`, which write to the
+ * vault-scoped browser `localStorage`. This is intentionally NOT part of the
+ * synced plugin settings (`data.json`): the flag MUST stay local to the device
+ * it is toggled on and MUST NEVER be synchronized to other devices.
+ */
+export const DEVICE_DISABLED_STORAGE_KEY = 'dataview-serializer:disabled-on-device'
+
 // Legacy syntax (original)
 export const QUERY_FLAG_OPEN = `<!-- QueryToSerialize: `
 export const QUERY_FLAG_MANUAL_OPEN = `<!-- QueryToSerializeManual: `

--- a/src/app/plugin.ts
+++ b/src/app/plugin.ts
@@ -61,6 +61,7 @@ import {
     type DataviewJSQueryWithContext
 } from './utils/find-dataviewjs-queries.fn'
 import { serializeDataviewJSQuery } from './utils/serialize-dataviewjs-query.fn'
+import { isDisabledOnDevice, setDisabledOnDevice } from './utils/device-disabled'
 
 /**
  * Maximum number of error notifications to show during batch operations
@@ -259,8 +260,9 @@ export class DataviewSerializerPlugin extends Plugin {
 
         await this.loadSettings()
 
-        // Only set up automatic event handlers if the user hasn't disabled them
-        if (!this.settings.disableAutomaticUpdates) {
+        // Only set up automatic event handlers if the user hasn't disabled them,
+        // and the plugin isn't disabled on this device.
+        if (!this.settings.disableAutomaticUpdates && !this.isDisabledOnDevice()) {
             this.setupEventHandlers()
         }
 
@@ -272,6 +274,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'serialize-all-dataview-queries',
             name: 'Scan and serialize all Dataview queries',
             callback: async () => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 log('Scanning and serializing all Dataview queries', 'debug')
                 const allVaultFiles = this.app.vault.getMarkdownFiles()
                 const allErrors: Array<{
@@ -314,6 +319,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'serialize-current-file-dataview-queries',
             name: 'Scan and serialize Dataview queries in current file',
             callback: async () => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 const activeFile = this.app.workspace.getActiveFile()
 
                 if (!activeFile) {
@@ -353,6 +361,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'insert-dataview-serializer-block',
             name: 'Insert query block',
             editorCallback: (editor) => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 const cursor = editor.getCursor()
                 const line = editor.getLine(cursor.line)
                 const indentation = line.match(/^(\s*)/)?.[1] || ''
@@ -386,6 +397,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'convert-dataview-query-at-cursor',
             name: 'Convert Dataview query at cursor to serialized format',
             editorCallback: async (editor) => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 const activeFile = this.app.workspace.getActiveFile()
 
                 if (!activeFile) {
@@ -465,6 +479,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'convert-all-dataview-queries-in-file',
             name: 'Convert all Dataview queries in current file to serialized format',
             editorCallback: async (editor) => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 const activeFile = this.app.workspace.getActiveFile()
 
                 if (!activeFile) {
@@ -508,6 +525,9 @@ export class DataviewSerializerPlugin extends Plugin {
             id: 'remove-all-queries-in-current-file',
             name: 'Remove all queries from current file',
             editorCallback: (editor) => {
+                if (this.blockedByDeviceDisable()) {
+                    return
+                }
                 const activeFile = this.app.workspace.getActiveFile()
 
                 if (!activeFile) {
@@ -540,7 +560,8 @@ export class DataviewSerializerPlugin extends Plugin {
                 this.app,
                 () => this.settings,
                 this.processFile.bind(this),
-                this.isFileIgnoredByFrontmatter.bind(this)
+                this.isFileIgnoredByFrontmatter.bind(this),
+                () => this.isDisabledOnDevice()
             )
         )
     }
@@ -695,6 +716,50 @@ export class DataviewSerializerPlugin extends Plugin {
     }
 
     /**
+     * Whether the plugin has been disabled on the current device.
+     *
+     * This flag is stored in device-local storage (never synced), so it reflects
+     * only the choice made on this device. When true the plugin is fully inert
+     * here: no automatic processing, no file mutations, commands no-op, and the
+     * per-query refresh buttons are hidden.
+     */
+    isDisabledOnDevice(): boolean {
+        return isDisabledOnDevice(this.app)
+    }
+
+    /**
+     * Guard used at the start of every command callback.
+     *
+     * When the plugin is disabled on this device, shows a notice and returns
+     * true so the caller can bail out without doing any work.
+     */
+    private blockedByDeviceDisable(): boolean {
+        if (this.isDisabledOnDevice()) {
+            new Notice('Dataview Serializer is disabled on this device', NOTICE_TIMEOUT)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Persist the per-device disable flag and apply it immediately.
+     *
+     * Disabling unregisters the file-event handlers; enabling re-registers them
+     * unless the synced "Disable automatic updates" setting is on. No reload is
+     * required: commands, `processFile`, and the refresh button all read the
+     * flag live.
+     */
+    setDisabledOnDevice(disabled: boolean): void {
+        setDisabledOnDevice(this.app, disabled)
+
+        if (disabled) {
+            this.unregisterEventHandlers()
+        } else if (!this.settings.disableAutomaticUpdates) {
+            this.setupEventHandlers()
+        }
+    }
+
+    /**
      * Add the event handlers
      */
     setupEventHandlers() {
@@ -770,6 +835,12 @@ export class DataviewSerializerPlugin extends Plugin {
         isManualTrigger = false
     ): Promise<FileProcessingResult> {
         const emptyResult: FileProcessingResult = { filePath: '', errors: [] }
+
+        // Fully inert when disabled on this device, regardless of how we got here
+        // (file events, schedulers, or any programmatic caller).
+        if (this.isDisabledOnDevice()) {
+            return emptyResult
+        }
 
         if (!(_file instanceof TFile)) {
             return emptyResult

--- a/src/app/refresh-button-extension.ts
+++ b/src/app/refresh-button-extension.ts
@@ -336,7 +336,8 @@ export const refreshButtonExtension = (
         targetQuery?: string,
         isManualTrigger?: boolean
     ) => Promise<FileProcessingResult>,
-    isFileIgnoredByFrontmatter: (file: TFile) => boolean
+    isFileIgnoredByFrontmatter: (file: TFile) => boolean,
+    isDeviceDisabled: () => boolean
 ) =>
     ViewPlugin.fromClass(
         class {
@@ -353,6 +354,12 @@ export const refreshButtonExtension = (
             }
 
             buildDecorations(view: EditorView): DecorationSet {
+                // Render no badges or refresh buttons when the plugin is disabled
+                // on this device.
+                if (isDeviceDisabled()) {
+                    return Decoration.none
+                }
+
                 const settings = getSettings()
                 const decorations: Array<{ from: number; to: number; decoration: Decoration }> = []
 

--- a/src/app/settings/settings-tab.ts
+++ b/src/app/settings/settings-tab.ts
@@ -22,6 +22,8 @@ export class SettingsTab extends PluginSettingTab {
 
         containerEl.empty()
 
+        this.renderDeviceDisabledBanner()
+        this.renderDeviceDisableToggle()
         this.renderAutomaticUpdatesToggle()
         this.renderRefreshButtonToggle()
         this.renderDataviewJSToggle()
@@ -33,6 +35,43 @@ export class SettingsTab extends PluginSettingTab {
         this.renderFoldersToIgnore()
         this.renderFoldersToForceUpdate()
         this.renderSupportSection(containerEl)
+    }
+
+    /**
+     * Show a prominent banner at the top of the tab when the plugin is disabled
+     * on the current device, so it's obvious why nothing is happening here.
+     */
+    renderDeviceDisabledBanner(): void {
+        if (!this.plugin.isDisabledOnDevice()) {
+            return
+        }
+
+        const banner = this.containerEl.createDiv({ cls: 'dvs-device-disabled-banner' })
+        banner.createEl('strong', { text: 'Disabled on this device.' })
+        banner.createSpan({
+            text: ' The plugin is inert here: no automatic serialization, file events, refresh buttons, or commands. This choice is device-local and is not synced to your other devices.'
+        })
+    }
+
+    /**
+     * Device-local toggle to fully disable the plugin on this device only.
+     *
+     * Stored in device-local storage (never synced), so it does not affect other
+     * devices. Applied immediately — no reload required.
+     */
+    renderDeviceDisableToggle(): void {
+        new Setting(this.containerEl)
+            .setName('Disable on this device')
+            .setDesc(
+                'When enabled, the plugin is fully disabled on this device only: it performs no automatic or manual serialization and its commands do nothing. This setting is stored locally and is never synced to your other devices.'
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.isDisabledOnDevice()).onChange((value) => {
+                    this.plugin.setDisabledOnDevice(value)
+                    // Re-render so the banner and dependent state reflect the change.
+                    this.display()
+                })
+            })
     }
 
     renderAutomaticUpdatesToggle(): void {

--- a/src/app/utils/device-disabled.spec.ts
+++ b/src/app/utils/device-disabled.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+import { isDisabledOnDevice, setDisabledOnDevice, type DeviceLocalStore } from './device-disabled'
+import { DEVICE_DISABLED_STORAGE_KEY } from '../constants'
+
+/**
+ * In-memory implementation of the device-local storage API for tests.
+ */
+class FakeStore implements DeviceLocalStore {
+    private readonly data = new Map<string, unknown>()
+
+    loadLocalStorage(key: string): unknown {
+        return this.data.has(key) ? this.data.get(key) : null
+    }
+
+    saveLocalStorage(key: string, value: unknown | null): void {
+        if (value === null) {
+            this.data.delete(key)
+        } else {
+            this.data.set(key, value)
+        }
+    }
+
+    has(key: string): boolean {
+        return this.data.has(key)
+    }
+}
+
+describe('isDisabledOnDevice', () => {
+    test('returns false when nothing is stored', () => {
+        expect(isDisabledOnDevice(new FakeStore())).toBe(false)
+    })
+
+    test('returns true after the flag is enabled', () => {
+        const store = new FakeStore()
+        setDisabledOnDevice(store, true)
+        expect(isDisabledOnDevice(store)).toBe(true)
+    })
+
+    test('returns false after the flag is disabled again', () => {
+        const store = new FakeStore()
+        setDisabledOnDevice(store, true)
+        setDisabledOnDevice(store, false)
+        expect(isDisabledOnDevice(store)).toBe(false)
+    })
+
+    test('treats unrelated stored values as enabled', () => {
+        const store = new FakeStore()
+        store.saveLocalStorage(DEVICE_DISABLED_STORAGE_KEY, 'something-else')
+        expect(isDisabledOnDevice(store)).toBe(false)
+    })
+})
+
+describe('setDisabledOnDevice', () => {
+    test('clears the storage entry when disabling is turned off', () => {
+        const store = new FakeStore()
+        setDisabledOnDevice(store, true)
+        expect(store.has(DEVICE_DISABLED_STORAGE_KEY)).toBe(true)
+
+        setDisabledOnDevice(store, false)
+        expect(store.has(DEVICE_DISABLED_STORAGE_KEY)).toBe(false)
+    })
+
+    test('round-trips through the storage key', () => {
+        const store = new FakeStore()
+        setDisabledOnDevice(store, true)
+        expect(store.loadLocalStorage(DEVICE_DISABLED_STORAGE_KEY)).toBe('true')
+    })
+})

--- a/src/app/utils/device-disabled.ts
+++ b/src/app/utils/device-disabled.ts
@@ -1,0 +1,40 @@
+import { DEVICE_DISABLED_STORAGE_KEY } from '../constants'
+
+/**
+ * Minimal view of the Obsidian `App` device-local storage API.
+ *
+ * `loadLocalStorage`/`saveLocalStorage` read and write the vault-scoped browser
+ * `localStorage`, which is never synced between devices. Declaring just the two
+ * methods we need keeps this helper unit-testable without a full `App` mock.
+ */
+export interface DeviceLocalStore {
+    loadLocalStorage(key: string): unknown
+    saveLocalStorage(key: string, data: unknown | null): void
+}
+
+/**
+ * Value written to device-local storage when the plugin is disabled on the
+ * current device. Any other stored value (including a missing entry) means the
+ * plugin is enabled.
+ */
+const DISABLED_VALUE = 'true'
+
+/**
+ * Returns true when the plugin has been disabled on the current device.
+ *
+ * The flag lives only in device-local storage, so this never reflects choices
+ * made on other (synced) devices.
+ */
+export const isDisabledOnDevice = (store: DeviceLocalStore): boolean => {
+    return store.loadLocalStorage(DEVICE_DISABLED_STORAGE_KEY) === DISABLED_VALUE
+}
+
+/**
+ * Persist the per-device disable flag.
+ *
+ * When disabling, writes the sentinel value; when enabling, clears the entry
+ * (passing `null` removes the key) so device-local storage stays tidy.
+ */
+export const setDisabledOnDevice = (store: DeviceLocalStore, disabled: boolean): void => {
+    store.saveLocalStorage(DEVICE_DISABLED_STORAGE_KEY, disabled ? DISABLED_VALUE : null)
+}

--- a/src/styles.src.css
+++ b/src/styles.src.css
@@ -11,6 +11,18 @@
     @apply mt-3;
 }
 
+/* Banner shown at the top of the settings tab when the plugin is disabled on this device */
+.dvs-device-disabled-banner {
+    @apply mb-4 p-3 rounded border;
+    background-color: color-mix(in srgb, var(--color-orange) 12%, transparent);
+    border-color: color-mix(in srgb, var(--color-orange) 35%, transparent);
+    color: var(--text-normal);
+}
+
+.dvs-device-disabled-banner strong {
+    color: var(--color-orange);
+}
+
 /* ============================================
    Query Marker Visual Decorations
    ============================================ */


### PR DESCRIPTION
Add a per-device switch that fully disables the plugin on the current device only, without syncing the choice to other devices.

The flag is stored via app.loadLocalStorage/saveLocalStorage (vault-scoped browser localStorage, never synced) rather than in PluginSettings/data.json, so it stays local to the device it is toggled on. These APIs are @since 1.8.7, so minAppVersion is bumped 1.4.10 -> 1.8.7.

When enabled the plugin is fully inert on that device: no file-event listeners, processFile short-circuits, all commands no-op with a notice, and the per-query refresh buttons render nothing. The toggle applies live with no reload required.